### PR TITLE
feat(auth): Add User/Role entities and initial Security setup

### DIFF
--- a/src/main/java/br/com/luizbrand/worklog/config/SecurityConfig.java
+++ b/src/main/java/br/com/luizbrand/worklog/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package br.com.luizbrand.worklog.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests( authorize -> authorize
+                        .anyRequest().permitAll())
+                .build();
+    }
+
+
+    @Bean
+    static RoleHierarchy roleHierarchy() {
+        return RoleHierarchyImpl.withDefaultRolePrefix()
+                .role("ADMIN").implies("USER")
+                .build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager (AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/br/com/luizbrand/worklog/entity/Role.java
+++ b/src/main/java/br/com/luizbrand/worklog/entity/Role.java
@@ -1,0 +1,38 @@
+package br.com.luizbrand.worklog.entity;
+
+import br.com.luizbrand.worklog.enums.RoleName;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity
+@Table(name = "roles")
+public class Role implements GrantedAuthority {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 120, unique = true, nullable = false)
+    private RoleName name;
+
+    @ManyToMany(mappedBy = "roles")
+    private Set<Users> users = new HashSet<>();
+
+
+    @Override
+    public String getAuthority() {
+        return "ROLE_" + name.name();
+    }
+}

--- a/src/main/java/br/com/luizbrand/worklog/entity/Users.java
+++ b/src/main/java/br/com/luizbrand/worklog/entity/Users.java
@@ -1,0 +1,56 @@
+package br.com.luizbrand.worklog.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity
+@Table(name = "users")
+public class Users {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "public_id", unique = true)
+    private UUID publicId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @ManyToMany
+    @JoinTable(
+            name = "user_role",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<Role> roles = new HashSet<>();
+
+}

--- a/src/main/java/br/com/luizbrand/worklog/enums/RoleName.java
+++ b/src/main/java/br/com/luizbrand/worklog/enums/RoleName.java
@@ -1,0 +1,6 @@
+package br.com.luizbrand.worklog.enums;
+
+public enum RoleName {
+    ADMIN,
+    USER,
+}


### PR DESCRIPTION
This pull request introduces the foundational components for user authentication and authorization by adding the Users and Role entities and setting up the initial Spring Security configuration.

Key Changes:
•JPA Entities:
        ◦Users.java: Represents an application user with fields for name, email, and password.
        ◦Role.java: Defines user roles (ADMIN, USER) and implements Spring Security's GrantedAuthority.
        ◦A many-to-many relationship is established between Users and Role.
•Spring Security Configuration (SecurityConfig.java):
        ◦Initializes the SecurityFilterChain with stateless session management, making it suitable for a REST API.
        ◦Disables CSRF protection.
        ◦For now, all endpoints are publicly accessible (.anyRequest().permitAll()) to facilitate initial development.◦Exposes essential beans:
                  ▪PasswordEncoder (BCryptPasswordEncoder) for secure password hashing.▪AuthenticationManager to handle authentication processes.
                  ▪RoleHierarchy to define that ADMIN inherits all USER permissions.
This PR closes #2 